### PR TITLE
fix: prevent creating duplicate requestTimes upon updating application

### DIFF
--- a/internal/routes/app/updateApp.go
+++ b/internal/routes/app/updateApp.go
@@ -30,7 +30,7 @@ func updateApp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	savedApp, err := app.FindOne(appId)
+	savedApp, err := app.FindAppDetails(appId)
 	if err != nil {
 		services.AppError(err.Error(), 400, w)
 		return


### PR DESCRIPTION
Stop creating duplicate copies of existing requestTimes for an application when updating its info